### PR TITLE
Fix Markdown syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@
 
         return this;
     }
-  ```
+    ```
 
     **[&#8593; Back to top](#TOC)**
 


### PR DESCRIPTION
Fix the indentation of a code block terminator (`` ``` ``) in the README.  Otherwise all sections after "Comments" are formatted as code.

![image](https://user-images.githubusercontent.com/1280900/28893347-a93d1d82-7796-11e7-9abd-daeea31ce638.png)
